### PR TITLE
Preparations to host other launches

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -13,8 +13,6 @@ use cw2::set_contract_version;
 use cw20::Cw20ExecuteMsg;
 use cw_asset::{Asset, AssetInfo};
 
-pub const SECONDS_PER_HOUR: u64 = 60 * 60;
-
 const CONTRACT_NAME: &str = "prism-forge";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -27,13 +25,19 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
+    if msg.host_portion >= Decimal::one() {
+        return Err(ContractError::InvalidHostPortion {});
+    }
+
     let cfg = Config {
-        owner: deps.api.addr_validate(&msg.owner)?,
+        operator: deps.api.addr_validate(&msg.operator)?,
         receiver: deps.api.addr_validate(&msg.receiver)?,
         token: deps.api.addr_validate(&msg.token)?,
         launch_config: None,
         base_denom: msg.base_denom,
         tokens_released: false,
+        host_portion: msg.host_portion,
+        host_portion_receiver: deps.api.addr_validate(&msg.host_portion_receiver)?,
     };
     TOTAL_DEPOSIT.save(deps.storage, &Uint128::zero())?;
     CONFIG.save(deps.storage, &cfg)?;
@@ -66,7 +70,7 @@ pub fn post_initialize(
     launch_config: LaunchConfig,
 ) -> Result<Response, ContractError> {
     let mut cfg = CONFIG.load(deps.storage)?;
-    if info.sender.as_str() != cfg.owner.as_str() {
+    if info.sender != cfg.operator {
         return Err(ContractError::Unauthorized {});
     }
 
@@ -81,8 +85,13 @@ pub fn post_initialize(
         return Err(ContractError::InvalidLaunchConfig {});
     }
 
-    // phase 2 must be longer than 1 hour, since we are using one hour slots
-    if (launch_config.phase2_end - launch_config.phase2_start) < SECONDS_PER_HOUR {
+    // phase 2 must be longer than the slot size
+    if (launch_config.phase2_end - launch_config.phase2_start) < launch_config.phase2_slot_period {
+        return Err(ContractError::InvalidLaunchConfig {});
+    }
+
+    // slot size can not be 0
+    if launch_config.phase2_slot_period == 0u64 {
         return Err(ContractError::InvalidLaunchConfig {});
     }
 
@@ -181,9 +190,10 @@ pub fn withdraw(
             });
         }
 
-        let current_slot = (launch_config.phase2_end - current_time) / SECONDS_PER_HOUR;
-        let total_slots =
-            (launch_config.phase2_end - launch_config.phase2_start) / SECONDS_PER_HOUR;
+        let current_slot =
+            (launch_config.phase2_end - current_time) / launch_config.phase2_slot_period;
+        let total_slots = (launch_config.phase2_end - launch_config.phase2_start)
+            / launch_config.phase2_slot_period;
         let withdrawable_portion =
             Decimal::from_ratio(current_slot + 1u64, total_slots).min(Decimal::one());
 
@@ -296,7 +306,7 @@ pub fn release_tokens(
     let mut cfg = CONFIG.load(deps.storage)?;
     let launch_cfg = cfg.launch_config.clone().unwrap();
 
-    if info.sender.as_str() != cfg.owner.as_str() {
+    if info.sender != cfg.operator {
         return Err(ContractError::Unauthorized {});
     }
 
@@ -327,7 +337,7 @@ pub fn admin_withdraw(
     let cfg = CONFIG.load(deps.storage)?;
     let launch_cfg = cfg.launch_config.unwrap();
 
-    if info.sender.as_str() != cfg.owner.as_str() {
+    if info.sender != cfg.operator {
         return Err(ContractError::Unauthorized {});
     }
 
@@ -338,17 +348,32 @@ pub fn admin_withdraw(
     }
 
     let balance = query_balance(&deps.querier, env.contract.address, cfg.base_denom.clone())?;
+    let host_portion = balance * cfg.host_portion;
 
-    let withdraw_asset = Asset {
-        info: AssetInfo::Native(cfg.base_denom),
-        amount: balance,
+    let base_denom_info = AssetInfo::Native(cfg.base_denom);
+    let host_withdraw_asset = Asset {
+        info: base_denom_info.clone(),
+        amount: host_portion,
+    };
+    let admin_withdraw_asset = Asset {
+        info: base_denom_info,
+        amount: balance - host_portion,
     };
 
-    // send the UST to the receiver specified in the contract config
-    let msg = withdraw_asset.transfer_msg(cfg.receiver)?;
-    Ok(Response::new().add_message(msg).add_attributes(vec![
+    let mut msgs: Vec<CosmosMsg> = vec![];
+    // because host_portion could be 0.0, check
+    if !host_withdraw_asset.amount.is_zero() {
+        msgs.push(host_withdraw_asset.transfer_msg(cfg.host_portion_receiver)?);
+    }
+
+    // send remaining amount to receiver
+    msgs.push(admin_withdraw_asset.transfer_msg(cfg.receiver)?);
+
+    Ok(Response::new().add_messages(msgs).add_attributes(vec![
         attr("action", "admin_withdraw"),
-        attr("withdraw_amount", balance.to_string()),
+        attr("total_withdraw_amount", balance.to_string()),
+        attr("host_amount", host_withdraw_asset.amount.to_string()),
+        attr("remaining_amount", admin_withdraw_asset.amount.to_string()),
     ]))
 }
 
@@ -378,9 +403,10 @@ pub fn query_deposit_info(deps: Deps, env: Env, address: String) -> StdResult<De
             if deposit_info.withdrew_phase2 || current_time >= launch_config.phase2_end {
                 Uint128::zero()
             } else {
-                let current_slot = (launch_config.phase2_end - current_time) / SECONDS_PER_HOUR;
-                let total_slots =
-                    (launch_config.phase2_end - launch_config.phase2_start) / SECONDS_PER_HOUR;
+                let current_slot =
+                    (launch_config.phase2_end - current_time) / launch_config.phase2_slot_period;
+                let total_slots = (launch_config.phase2_end - launch_config.phase2_start)
+                    / launch_config.phase2_slot_period;
 
                 let withdrawable_portion =
                     Decimal::from_ratio(current_slot + 1u64, total_slots).min(Decimal::one());

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,9 @@ pub enum ContractError {
     #[error("Invalid launch config")]
     InvalidLaunchConfig {},
 
+    #[error("Invalid host portion: it should be smaller than 1.0")]
+    InvalidHostPortion {},
+
     #[error("Invalid deposit: {reason}")]
     InvalidDeposit { reason: String },
 

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -10,14 +10,18 @@ pub struct LaunchConfig {
     // phase2: can withdraw one time. Allowed withdraw decreases 100% to 0% over time.
     pub phase2_start: u64,
     pub phase2_end: u64,
+    // time in seconds for each slot in phase2
+    pub phase2_slot_period: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    pub owner: String,
+    pub operator: String,
     pub receiver: String,
     pub token: String,
     pub base_denom: String,
+    pub host_portion: Decimal,
+    pub host_portion_receiver: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -40,12 +44,14 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ConfigResponse {
-    pub owner: String,
+    pub operator: String,
     pub receiver: String,
     pub token: String,
     pub launch_config: Option<LaunchConfig>,
     pub base_denom: String,
     pub tokens_released: bool,
+    pub host_portion: Decimal,
+    pub host_portion_receiver: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use crate::msg::{ConfigResponse, LaunchConfig};
-use cosmwasm_std::{Addr, StdResult, Uint128};
+use cosmwasm_std::{Addr, Decimal, StdResult, Uint128};
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -12,23 +12,27 @@ pub const DEPOSITS: Map<&Addr, DepositInfo> = Map::new("deposits");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
-    pub owner: Addr,
+    pub operator: Addr,
     pub receiver: Addr,
     pub token: Addr,
     pub launch_config: Option<LaunchConfig>,
     pub base_denom: String,
     pub tokens_released: bool,
+    pub host_portion: Decimal,
+    pub host_portion_receiver: Addr,
 }
 
 impl Config {
     pub fn as_res(&self) -> StdResult<ConfigResponse> {
         let res = ConfigResponse {
-            owner: self.owner.to_string(),
+            operator: self.operator.to_string(),
             receiver: self.receiver.to_string(),
             token: self.token.to_string(),
             launch_config: self.launch_config.clone(),
             base_denom: self.base_denom.clone(),
             tokens_released: self.tokens_released,
+            host_portion: self.host_portion,
+            host_portion_receiver: self.host_portion_receiver.to_string(),
         };
         Ok(res)
     }

--- a/src/testing/tests.rs
+++ b/src/testing/tests.rs
@@ -2,23 +2,27 @@ use cosmwasm_std::testing::{
     mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MOCK_CONTRACT_ADDR,
 };
 use cosmwasm_std::{
-    attr, from_binary, to_binary, Addr, BankMsg, Coin, CosmosMsg, Deps, DepsMut, Env,
+    attr, from_binary, to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env,
     MemoryStorage, MessageInfo, OwnedDeps, Response, StdResult, SubMsg, Uint128, WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
 
-use crate::contract::{deposit, execute, instantiate, query, release_tokens, SECONDS_PER_HOUR};
+use crate::contract::{deposit, execute, instantiate, query, release_tokens};
 use crate::error::ContractError;
 use crate::msg::{
     ConfigResponse, DepositResponse, ExecuteMsg, InstantiateMsg, LaunchConfig, QueryMsg,
 };
 
+const SECONDS_PER_HOUR: u64 = 60 * 60;
+
 pub fn init(deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier>) {
     let msg = InstantiateMsg {
-        owner: "owner0001".to_string(),
+        operator: "owner0001".to_string(),
         receiver: "receiver0000".to_string(),
         token: "prism0001".to_string(),
         base_denom: "uusd".to_string(),
+        host_portion: Decimal::zero(),
+        host_portion_receiver: "host0000".to_string(),
     };
 
     let info = mock_info("owner0001", &[]);
@@ -34,6 +38,7 @@ pub fn post_init(deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier>) {
         phase1_start: env.block.time.seconds(),
         phase2_start: env.block.time.seconds() + 100,
         phase2_end: env.block.time.seconds() + 100 + SECONDS_PER_HOUR,
+        phase2_slot_period: SECONDS_PER_HOUR,
     };
     do_post_initialize(deps.as_mut(), env, info, launch_config).unwrap();
 }
@@ -103,12 +108,14 @@ fn proper_post_initialize() {
     assert_eq!(
         config_response,
         ConfigResponse {
-            owner: "owner0001".to_string(),
+            operator: "owner0001".to_string(),
             receiver: "receiver0000".to_string(),
             token: "prism0001".to_string(),
             launch_config: None,
             base_denom: "uusd".to_string(),
             tokens_released: false,
+            host_portion: Decimal::zero(),
+            host_portion_receiver: "host0000".to_string(),
         }
     );
 
@@ -119,6 +126,7 @@ fn proper_post_initialize() {
         phase1_start: env.block.time.seconds(),
         phase2_start: env.block.time.seconds() + 100,
         phase2_end: env.block.time.seconds() + 100 + SECONDS_PER_HOUR,
+        phase2_slot_period: SECONDS_PER_HOUR,
     };
 
     // unauthorized
@@ -191,12 +199,14 @@ fn proper_post_initialize() {
     assert_eq!(
         config_response,
         ConfigResponse {
-            owner: "owner0001".to_string(),
+            operator: "owner0001".to_string(),
             receiver: "receiver0000".to_string(),
             token: "prism0001".to_string(),
             launch_config: Some(launch_config.clone()),
             base_denom: "uusd".to_string(),
             tokens_released: false,
+            host_portion: Decimal::zero(),
+            host_portion_receiver: "host0000".to_string(),
         }
     );
 
@@ -470,6 +480,7 @@ fn proper_withdraw_phase3() {
         phase1_start: env.block.time.seconds(),
         phase2_start: env.block.time.seconds() + 100,
         phase2_end: env.block.time.seconds() + 100 + 24 * SECONDS_PER_HOUR, // 24 hour phase 2
+        phase2_slot_period: SECONDS_PER_HOUR,
     };
     do_post_initialize(deps.as_mut(), mock_env(), info, launch_config).unwrap();
 
@@ -917,7 +928,9 @@ fn proper_admin_withdraw() {
         res.attributes,
         vec![
             attr("action", "admin_withdraw"),
-            attr("withdraw_amount", "6000"),
+            attr("total_withdraw_amount", "6000"),
+            attr("host_amount", "0"),
+            attr("remaining_amount", "6000"),
         ]
     );
     assert_eq!(
@@ -957,5 +970,81 @@ fn proper_admin_withdraw() {
             tokens_to_claim: Uint128::from(166666u128), // 1000000 * 1000 / 6000
             can_claim: true,                      // now users can claim tokens
         }
+    );
+}
+
+#[test]
+fn proper_admin_withdraw_with_host() {
+    let mut deps = mock_dependencies(&[]);
+
+    let msg = InstantiateMsg {
+        operator: "owner0001".to_string(),
+        receiver: "receiver0000".to_string(),
+        token: "prism0001".to_string(),
+        base_denom: "uusd".to_string(),
+        host_portion: Decimal::percent(10), // 10% host portion
+        host_portion_receiver: "host0000".to_string(),
+    };
+
+    let owner_info = mock_info("owner0001", &[]);
+    let mut env = mock_env();
+    instantiate(deps.as_mut(), env.clone(), owner_info.clone(), msg).unwrap();
+
+    post_init(&mut deps);
+
+    let mut info1 = mock_info("addr0001", &[]);
+    let mut info2 = mock_info("addr0002", &[]);
+
+    // successful deposits -- total 6,000 uusd
+    info1.funds = vec![Coin::new(1_000, "uusd")];
+    let res = do_deposit(deps.as_mut(), env.clone(), info1.clone());
+    assert_eq!(res.unwrap().messages.len(), 0);
+
+    info2.funds = vec![Coin::new(5_000, "uusd")];
+    let res = do_deposit(deps.as_mut(), env.clone(), info2);
+    assert_eq!(res.unwrap().messages.len(), 0);
+
+    // update contract balance after deposits
+    deps.querier.update_balance(
+        MOCK_CONTRACT_ADDR.to_string(),
+        vec![Coin::new(6_000, "uusd")],
+    );
+
+    // fast forward past phase 2
+    env.block.time = env.block.time.plus_seconds(100 + SECONDS_PER_HOUR);
+
+    // now admin can withdraw uusd -- unauthorized attempt
+    let err = do_admin_withdraw(deps.as_mut(), env.clone(), info1).unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized {});
+
+    // valid attempt
+    let res = do_admin_withdraw(deps.as_mut(), env, owner_info).unwrap();
+    assert_eq!(
+        res.attributes,
+        vec![
+            attr("action", "admin_withdraw"),
+            attr("total_withdraw_amount", "6000"),
+            attr("host_amount", "600"),
+            attr("remaining_amount", "5400"),
+        ]
+    );
+    assert_eq!(
+        res.messages,
+        vec![
+            SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+                to_address: "host0000".to_string(), // host address specified on contract instantiation
+                amount: vec![Coin {
+                    denom: "uusd".to_string(),
+                    amount: Uint128::from(600u128), // 600
+                }],
+            })),
+            SubMsg::new(CosmosMsg::Bank(BankMsg::Send {
+                to_address: "receiver0000".to_string(), // receiver address specified on contract instantiation
+                amount: vec![Coin {
+                    denom: "uusd".to_string(),
+                    amount: Uint128::from(5400u128), // 5400
+                }],
+            }))
+        ]
     );
 }


### PR DESCRIPTION
- Set a `host_portion` and `host_portion_receiver` as parameter.
- Admin withdraw logic altered
- The phase 2 slot length is now a config parameter, not hardcoded.